### PR TITLE
add hospitalized and remove need for 2 urls

### DIFF
--- a/crawler.rb
+++ b/crawler.rb
@@ -233,40 +233,7 @@ byebug
   end
 
   def parse_ca(h)
-    #CaCrawler.new(driver: @driver, url: @url, st: @st).call
-    crawl_page
-    sec = SEC/5
-    loop do
-      @s = @driver.find_elements(id: 's4-workspace').first.text.gsub(/\s+/,' ')
-      if @s =~ /there are a total of (.*) positive cases and (.*) deaths /
-        h[:positive] = string_to_i($1)
-        h[:deaths] = string_to_i($2)
-        break
-      elsif sec == 0
-        @errors << 'CA parse failed'
-        break
-      end
-      sec -= 1
-      puts "sleeping...#{sec}"
-      sleep 1
-    end
-    url = 'https://www.cdph.ca.gov/Programs/OPA/Pages/New-Release-2020.aspx'
-    crawl_page url
-    urls = @driver.page_source.scan(/Programs\/OPA\/Pages\/NR[^"']+/).map {|i| 'https://www.cdph.ca.gov/' + i}.sort.reverse # NR20-32.aspx
-    url = urls.shift
-    while url =~ /NR20-32.aspx/
-      url = urls.shift
-    end
-    # Negative from CDPH report of 778 tests on 3/7, and 88 pos => 690 neg
-    crawl_page url
-    if (x=@driver.find_element(id: 'MainContent')) && x.text =~ /pproximately ([0-9,]+)([\+\*]+)? tests had been conducted in California/
-      h[:tested] = string_to_i($1)
-    else
-      byebug unless @auto_flag
-      @errors << 'missing tested'
-    end
-    # TODO source is 2 urls
-    h
+    CaCrawler.new(driver: @driver, url: @url, st: @st).call
   end
 
   def parse_co(h)

--- a/crawlers/states/ca_crawler.rb
+++ b/crawlers/states/ca_crawler.rb
@@ -4,19 +4,48 @@ class CaCrawler < BaseCrawler
 
   protected
 
+  def _set_up_page
+    url = wait.until {
+      @driver.find_element(xpath: "//a[contains(@title, 'Latest COVID-19 Facts')]")
+    }.attribute('href')
+    return unless url
+
+    crawl_page url
+
+    html_element = wait.until {
+      @driver.find_element(xpath: "//div[@id='WebPartWPQ4']")
+    }
+    return unless html_element
+
+    # Text from HTML
+    @_page_elements = html_element.text.tr(',', '')
+
+    # Text from image
+    image_element = html_element.find_element(xpath: "//img[contains(@alt, 'CA_COVID-19')]")
+    image_url     = image_element.attribute('src')
+    @_image_text  = RTesseract.new(image_url).to_s.tr(',', '')
+
+    true
+  end
+
   def _find_positive
-    #@results[:positive] = w[1].to_i
+    @results[:positive] = /(\d+) confirmed cases/.match(@_page_elements)[1]&.to_i
   end
 
   def _find_deaths
-    #w = /(\d+)\s*Deaths/.match(image_string)
-    #return unless w
-    #@results[:deaths] = w[1].to_i
+    @results[:deaths] = /(\d+) deaths/.match(@_page_elements)[1]&.to_i
   end
 
   def _find_tested
-    #w = /(\d+)\s*Tested/.match(image_string)
-    #return unless w
-    #@results[:tested] = w[1].to_i
+    @results[:tested] = /(\d+) tests/.match(@_page_elements)[1]&.to_i
+  end
+
+  def _find_hospitalized
+    hospitalized = /-> (\d+)\/\d+ (\d+)/.match(@_image_text)
+    hospitalized_confirmed = hospitalized[1]&.to_i
+    hospitalized_suspected = hospitalized[2]&.to_i
+
+    @results[:hospitalized] = hospitalized_confirmed + hospitalized_suspected
   end
 end
+

--- a/states.csv
+++ b/states.csv
@@ -2,7 +2,7 @@ AK	http://dhss.alaska.gov/dph/Epi/id/Pages/COVID-19/monitoring.aspx
 AL	http://alabamapublichealth.gov/covid19/index.html
 AR	https://www.healthy.arkansas.gov/programs-services/topics/novel-coronavirus
 AZ	https://tableau.azdhs.gov/views/COVID-19Dashboard/COVID-19table?:isGuestRedirectFromVizportal=y&:embed=y
-CA	https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/Immunization/ncov2019.aspx
+CA	https://www.cdph.ca.gov/Programs/OPA/Pages/New-Release-2020.aspx
 CO	https://covid19.colorado.gov/data
 CT	https://portal.ct.gov/Coronavirus
 DC	https://coronavirus.dc.gov/page/coronavirus-data


### PR DESCRIPTION
We could use [this page](https://www.cdph.ca.gov/Programs/OPA/Pages/New-Release-2020.aspx) to fetch last report. It contains all data that we need, thus removing the need for 2 URLs

As my Tesseract version doesn't support URLs, I've been using downloaded images while developing this. I quickly adjusted it at the end, assuming that the production server supports URLs. Apologies if it's broken when you test it (it shouldn't be) !