### PR TITLE
Save image and fix CA

### DIFF
--- a/crawlers/base_crawler.rb
+++ b/crawlers/base_crawler.rb
@@ -85,6 +85,27 @@ class BaseCrawler
     end
   end
 
+  def save_image(url)
+    return unless url
+
+    begin
+      @driver.navigate.to url
+      extension = /\.\w+$/.match(url).to_s
+
+      wait.until {
+        @driver.find_element(xpath: '//img').displayed?
+      }
+
+      @driver.save_screenshot("#{@path}#{@st}/image_#{@filetime}#{extension}")
+    rescue Selenium::WebDriver::Error::NoSuchElementError => e
+      @errors << "crawler failed to save image for #{@st} at #{url}: #{e.inspect}"
+    ensure
+      @driver.navigate.back
+    end
+
+    true
+  end
+
   protected
 
   def _set_up_page

--- a/crawlers/states/ca_crawler.rb
+++ b/crawlers/states/ca_crawler.rb
@@ -18,12 +18,13 @@ class CaCrawler < BaseCrawler
     return unless html_element
 
     # Text from HTML
-    @_page_elements = html_element.text.tr(',', '')
+    @_page_elements = html_element.text.delete(',')
 
     # Text from image
     image_element = html_element.find_element(xpath: "//img[contains(@alt, 'CA_COVID-19')]")
     image_url     = image_element.attribute('src')
-    @_image_text  = RTesseract.new(image_url).to_s.tr(',', '')
+    @_image_text  = RTesseract.new('img.png').to_s.delete(',')
+    save_image(image_url)
 
     true
   end
@@ -41,7 +42,7 @@ class CaCrawler < BaseCrawler
   end
 
   def _find_hospitalized
-    hospitalized = /-> (\d+)\/\d+ (\d+)/.match(@_image_text)
+    hospitalized = /(\d+)\/\d+ (\d+)\/\d+/.match(@_image_text)
     hospitalized_confirmed = hospitalized[1]&.to_i
     hospitalized_suspected = hospitalized[2]&.to_i
 

--- a/crawlers/states/ca_crawler.rb
+++ b/crawlers/states/ca_crawler.rb
@@ -23,7 +23,7 @@ class CaCrawler < BaseCrawler
     # Text from image
     image_element = html_element.find_element(xpath: "//img[contains(@alt, 'CA_COVID-19')]")
     image_url     = image_element.attribute('src')
-    @_image_text  = RTesseract.new('img.png').to_s.delete(',')
+    @_image_text  = RTesseract.new(image_url).to_s.delete(',')
     save_image(image_url)
 
     true

--- a/crawlers/states/tn_crawler.rb
+++ b/crawlers/states/tn_crawler.rb
@@ -10,6 +10,7 @@ class TnCrawler < BaseCrawler
 
     image_url = image.attribute('src')
     image_string = RTesseract.new(image_url).to_s.strip.tr("\n", ' ').tr(',', '')
+    save_image(image_url)
     w = /(\d+)\s*Hospitalized/.match(image_string)
     return unless w
 
@@ -22,6 +23,7 @@ class TnCrawler < BaseCrawler
 
     image_url = image.attribute('src')
     image_string = RTesseract.new(image_url).to_s.strip.tr("\n", ' ').tr(',', '')
+    save_image(image_url)
     w = /(\d+)\s*Cases/.match(image_string)
     return unless w
 
@@ -34,6 +36,7 @@ class TnCrawler < BaseCrawler
 
     image_url = image.attribute('src')
     image_string = RTesseract.new(image_url).to_s.strip.tr("\n", ' ').tr(',', '')
+    save_image(image_url)
     w = /(\d+)\s*Deaths/.match(image_string)
     return unless w
 
@@ -46,6 +49,7 @@ class TnCrawler < BaseCrawler
 
     image_url = image.attribute('src')
     image_string = RTesseract.new(image_url).to_s.strip.tr("\n", ' ').tr(',', '')
+    save_image(image_url)
     w = /(\d+)\s*Deaths/.match(image_string)
     return unless w
 
@@ -61,6 +65,7 @@ class TnCrawler < BaseCrawler
 
     image_url = image.attribute('src')
     image_string = RTesseract.new(image_url).to_s.strip.tr("\n", ' ').tr(',', '')
+    save_image(image_url)
     w = /(\d+)\s*Tested/.match(image_string)
     unless w
       @errors << 'parse failed for tested'


### PR DESCRIPTION
Maybe  :save_image should move ("scroll") to the element instead of GETing the URL and navigate back... Something like this:
```ruby
def save_image(element) # Selenium Element object
  @driver.action.move_to(element)
  @driver.save_screenshot(path)
end
```
Let me know and I'll edit it if you think it's better this way