### PR TITLE
Error handling, CLI rewrite

### DIFF
--- a/bin/crawl
+++ b/bin/crawl
@@ -1,10 +1,5 @@
 #!/usr/bin/env ruby
 
-require './crawler'
+require_relative '../crawler'
 
-#
-# usage: ./bin/crawl [optional list of states]
-#
-
-crawler = Crawler.new
-errors = crawler.run(ARGV, false)
+CrawlAndParse::CLI.new(ARGV).call

--- a/bin/crawl_all
+++ b/bin/crawl_all
@@ -1,18 +1,15 @@
 #!/usr/bin/env ruby
 
-require './crawler'
+require_relative '../crawler'
 
-crawler = Crawler.new
-crawler.run(['ak', "az", 'ca', 'ct', 'ia', 'id', 'ks', 'ma', 'mi', "nd", 'ny', 'oh', 'ok', 'pr', 'ri', 'sd', 'vt', 'wi', 'wy'], false)
+states = %w[ak az ca ct ia id ks ma mi nd ny oh ok pr ri sd vt wi wy]
 
-errors = crawler.run
+errors = CrawlAndParse::CLI.new(states << '--nofail').call
 
-puts
-puts 'done with full run'
-puts
+puts "\ndone with full run\n"
 
-while errors.size > 0
-  puts "ready to run errors again:"
+until errors.empty?
+  puts 'ready to run errors again:'
   byebug
-  errors = crawler.run(errors)
+  errors = CrawlAndParse::CLI.new(errors).run
 end

--- a/bin/crawl_auto
+++ b/bin/crawl_auto
@@ -1,6 +1,3 @@
 #!/usr/bin/env ruby
 
-require './crawler'
-
-crawler = Crawler.new
-errors = crawler.run(ARGV)
+exec "#{__dir__}/crawl --auto"

--- a/crawler.rb
+++ b/crawler.rb
@@ -1865,6 +1865,8 @@ byebug unless @auto_flag
         h = send("parse_#{@st}", h)
         @errors += h[:errors]
       rescue => e
+        raise unless CrawlAndParse.nofail
+
         byebug unless @auto_flag
         @errors << "parse_#{@st} crashed: #{e.inspect}"
       end

--- a/crawler.rb
+++ b/crawler.rb
@@ -1,5 +1,9 @@
-require './lib/utils'
-require './crawlers/base_crawler'
+# Used for making sure we drop data files in the correct path:
+BASEDIR = __dir__
+
+require_relative './lib/cli'
+require_relative './lib/utils'
+require_relative './crawlers/base_crawler'
 Dir['./crawlers/states/*.rb'].sort.each { |file| require file }
 
 # not automatic:
@@ -20,10 +24,6 @@ Dir['./crawlers/states/*.rb'].sort.each { |file| require file }
 SEC = 30 # seconds to wait for page to load
 OFFSET = nil # if set, start running at that state
 SKIP_LIST = [] # skip these states
-
-# Used for making sure we drop data files in the correct path:
-BASEDIR = __dir__
-
 =begin
 
 Structure of the hash h, where STATE crawl data is stored
@@ -1782,7 +1782,10 @@ byebug unless @auto_flag
   end
 
 
-  def initialize
+  # Options is a struct created by the CLI class
+  def initialize(crawl_list)
+    @options = CrawlAndParse.options
+    @crawl_list = crawl_list
 
     profile = Selenium::WebDriver::Firefox::Profile.new
     #profile.add_extension("/path/to/extension.xpi")
@@ -1824,8 +1827,10 @@ byebug unless @auto_flag
   # or you can specifiy the list of states to run
   # if auto_flag is false, will prompt you for certain states
   #
-  def run(crawl_list = [], auto_flag = true, debug_page_flag = false)
-    @auto_flag = auto_flag
+  def run
+    @auto_flag = CrawlAndParse.auto
+    debug_page_flag = CrawlAndParse.debug
+    crawl_list = @crawl_list
     h_all = []
     errors_crawl = []
     warnings_crawl = []

--- a/crawlers/base_crawler.rb
+++ b/crawlers/base_crawler.rb
@@ -27,10 +27,7 @@ class BaseCrawler
         f.puts @driver.page_source
       end
     rescue StandardError => e
-      # If we're going to blindly catch every error, at least let me see the
-      # stack trace.
-
-      byebug
+      raise unless CrawlAndParse.nofail
 
       @errors << "crawler failed for #{@st}: #{e.inspect}"
     end
@@ -78,6 +75,8 @@ class BaseCrawler
         f.puts @driver.page_source
       end
     rescue StandardError
+      raise unless CrawlAndParse.nofail
+
       @errors << "crawler failed for #{@st}: #{e.inspect}"
     end
   end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -1,0 +1,85 @@
+require 'optparse'
+
+# Eventually this will be the top level namespace.
+module CrawlAndParse
+  Options = Struct.new(:auto, :nofail, :debug, keyword_init: true)
+
+  # This allows us to call CrawlAndParse.(property), saving us from
+  # having to pass a bunch of arguments to all the different constructors
+  class << self
+    attr_accessor :options
+
+    # Delegate missing methods to the options hash. Allows us to call things
+    # like CrawlAndParse.nofail instead of CrawlAndParse.options.nofail
+    def method_missing(method, *args)
+      super unless options.respond_to? method
+
+      options.send(method, *args)
+    end
+
+    def respond_to_missing?(method)
+      super || options.respond_to?(method)
+    end
+  end
+
+  # Parses Command line args, passes them to the main crawler
+  class CLI
+    def initialize(argv)
+      @argv = argv
+      @options = defaults
+
+      # Handles flagged arguments
+      parser.parse!(@argv, into: @options)
+    end
+
+    def call
+      CrawlAndParse.options = options
+      Crawler.new(crawl_list).run
+    end
+
+    private
+
+    # Parses remaining (unflagged) arguments
+    def crawl_list
+      help unless @argv.any? || @options[:auto]
+
+      # TODO: Verify that state arguments make sense.
+      @crawl_list = @argv.map(&:downcase)
+    end
+
+    def options
+      Options.new(@options)
+    end
+
+    def defaults
+      { auto: false, nofail: false, debug: false }
+    end
+
+    def parser
+      OptionParser.new do |opts|
+        opts.banner = banner
+
+        opts.on('-a', '--auto', 'Automatically crawl all states')
+        opts.on('-h', '--help', 'Print Help') { help }
+        opts.on('-n', '--nofail', 'Catch all exceptions')
+        opts.on('-d', '--debug',
+                "I'm not actually sure. I think it starts a debugger on errors")
+      end
+    end
+
+    def banner
+      <<~BANNER
+
+        Usage: crawl [options] [states]
+        
+        You must either give some states or pass the auto flag.
+
+      BANNER
+    end
+
+    def help
+      puts parser
+      exit
+    end
+  end
+end


### PR DESCRIPTION
* Create a proper Command Line Interface
* Change error handling behavior: If `--nofail` argument is not explicitly passed, do not blindly catch all exceptions.

If you like, we can change the default behavior so it does catch them unless explicitly told not to. This is a bad practice, though.

I rewrote the `bin/crawl*` scripts; they should have the same behavior but I'm not entirely sure how you use them so it might have changed. Don't merge this without testing it! 